### PR TITLE
fix build issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,7 @@ message(STATUS "Selected game version: " ${GAME_VERSION} " || Protocol: " ${PROT
 
 
 add_subdirectory(3rdparty/botcraft/protocolCraft)
+
+set_target_properties(protocolCraft PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/lib")
+
 add_subdirectory(sniffcraft)


### PR DESCRIPTION
cmake was trying to install the protocolCraft archive file under /lib which is an elevated permission directory thus making the build fail
I don't know if you're ok with the archive being saved under /bin/lib, change it if there's a better location for it