### PR TITLE
Add macOS to Github Actions

### DIFF
--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -25,6 +25,10 @@ jobs:
               name: Linux,
               os: ubuntu-latest
             }
+          - {
+              name: macOS,
+              os: macos-latest
+            }
     uses: ./.github/workflows/sniffcraft_build.yml
     with:
       os: ${{ matrix.config.os }}
@@ -50,6 +54,12 @@ jobs:
         with:
           name: sniffcraft-Windows
           path: windows
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: sniffcraft-macOS
+          path: macos
 
       - name: Download version artifact
         uses: actions/download-artifact@v3
@@ -78,6 +88,7 @@ jobs:
         run: |
           mv linux/sniffcraft sniffcraft-linux-${{ steps.mc-version.outputs.version }}
           mv windows/sniffcraft.exe sniffcraft-windows-${{ steps.mc-version.outputs.version }}.exe
+          mv macos/sniffcraft sniffcraft-macos-${{ steps.mc-version.outputs.version }}
 
       - name: Remove old latest release
         run: gh release delete latest --repo ${{ github.repository }} --cleanup-tag -y
@@ -89,6 +100,7 @@ jobs:
           gh release create latest
           sniffcraft-linux-${{ steps.mc-version.outputs.version }}
           sniffcraft-windows-${{ steps.mc-version.outputs.version }}.exe
+          sniffcraft-macos-${{ steps.mc-version.outputs.version }}
           --repo ${{ github.repository }}
           --latest
           -F release_note.txt

--- a/.github/workflows/on_issue_version_request.yml
+++ b/.github/workflows/on_issue_version_request.yml
@@ -46,6 +46,10 @@ jobs:
               name: Linux,
               os: ubuntu-latest
             }
+          - {
+              name: MacOS,
+              os: macos-latest
+            }
     uses: ./.github/workflows/sniffcraft_build.yml
     with:
       os: ${{ matrix.config.os }}
@@ -98,16 +102,24 @@ jobs:
           name: sniffcraft-Windows
           path: windows
 
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: sniffcraft-macOS
+          path: macos
+
       - name: Rename artifacts
         run: |
           mv linux/sniffcraft sniffcraft-linux-${{ needs.check_if_build_needed.outputs.version }}
           mv windows/sniffcraft.exe sniffcraft-windows-${{ needs.check_if_build_needed.outputs.version }}.exe
+          mv macos/sniffcraft sniffcraft-macos-${{ needs.check_if_build_needed.outputs.version }}
 
       - name: Upload files to release
         run: >
           gh release upload latest
           sniffcraft-linux-${{ needs.check_if_build_needed.outputs.version }}
           sniffcraft-windows-${{ needs.check_if_build_needed.outputs.version }}.exe
+          sniffcraft-macos-${{ needs.check_if_build_needed.outputs.version }}
           --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This adds x86_64 macOS support to CI. Tested it, binary seems to work flawlessly under M1 Rosetta.
I'd have added aarch64 support but I'm not comfortable with CMake and Rosetta seems to work fine.